### PR TITLE
feat: add log printing from dump

### DIFF
--- a/moto/cli.py
+++ b/moto/cli.py
@@ -67,6 +67,24 @@ def _ingest_upstream_channels(channels, influx, progress):
         progress.update(task, advance=1)
 
 
+def _print_logs(logs, progress):
+    table = Table(
+        "Timestamp",
+        "Level",
+        "Message",
+        title="Modem Logs",
+    )
+
+    for log in sorted(logs, key=lambda x: x.timestamp):
+        table.add_row(
+            log.timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+            log.level,
+            log.message,
+        )
+
+    progress.console.print(table)
+
+
 def _print_downstream_channels(channels, progress):
     table = Table(
         "Channel",
@@ -159,6 +177,9 @@ def dump():
 
         channels = _get_upstream_channels(moto, progress)
         _print_upstream_channels(channels, progress)
+
+        logs = _get_logs(moto, progress)
+        _print_logs(logs, progress)
 
 
 def _ingest():


### PR DESCRIPTION
Thought it would be useful to see log messages from the modem without having to set up InfluxDB.

This FR adds a table of log messages when a user runs `moto dump`

```text
┏━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Timestamp           ┃ Level        ┃ Message                                                               ┃
┡━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ 2024-07-05 15:05:37 │ Critical (3) │ Started Unicast Maintenance Ranging - No Response received - T3       │
│                     │              │ time-out;CM-MAC=XX:XX:XX:XX:XX:XX;CMTS-MAC=XX:XX:XX:XX:XX:XX;CM-QOS=… │
│ 2024-07-05 15:06:53 │ Warning (5)  │ MDD message                                                           │
│                     │              │ timeout;CM-MAC=XX:XX:XX:XX:XX:XX;CMTS-MAC=XX:XX:XX:XX:XX:XX;CM-QOS=1… │
│ 2024-07-05 15:06:54 │ Notice (6)   │ CM-STATUS message sent. Event Type Code: 4; Chan ID: 2 3 4 5 6 7 9 11 │
│                     │              │ 12 24 27 28 29 30 31 32; DSID: N/A; MAC Addr: N/A; OFDM/OFDMA Profile │
│                     │              │ ID:                                                                   │
│                     │              │ N/A.;CM-MAC=XX:XX:XX:XX:XX:XX;CMTS-MAC=XX:XX:XX:XX:XX:XX;CM-QOS=1…    │
└─────────────────────┴──────────────┴───────────────────────────────────────────────────────────────────────┘
```